### PR TITLE
Add opt-out option and profile tracking

### DIFF
--- a/moon/autorun/gm_mixpanel.moon
+++ b/moon/autorun/gm_mixpanel.moon
@@ -7,19 +7,20 @@ playerIdentifierEvent = "Mixpanel_PlayerIdentifier"
 if SERVER
     AddCSLuaFile "includes/modules/mixpanel.lua"
     AddCSLuaFile "gm_mixpanel/cl_mixpanel.lua"
+    AddCSLuaFile "gm_mixpanel/cl_menu.lua"
     AddCSLuaFile "gm_mixpanel/base.lua"
 
     util.AddNetworkString playerIdentifierEvent
     net.Receive playerIdentifierEvent, (_, ply) ->
         net.Start playerIdentifierEvent
         net.WriteString CRC ply\IPAddress!
-        net.Send ply
+    net.Send ply
 
 if CLIENT
     hook.Add "Think", playerIdentifierEvent, ->
         hook.Remove "Think", playerIdentifierEvent
         net.Start playerIdentifierEvent
-        net.SendToServer!
+    net.SendToServer!
 
     net.Receive playerIdentifierEvent, ->
         LocalPlayer!.mixpanelIdentifier = net.ReadString!

--- a/moon/autorun/gm_mixpanel.moon
+++ b/moon/autorun/gm_mixpanel.moon
@@ -14,13 +14,13 @@ if SERVER
     net.Receive playerIdentifierEvent, (_, ply) ->
         net.Start playerIdentifierEvent
         net.WriteString CRC ply\IPAddress!
-    net.Send ply
+        net.Send ply
 
 if CLIENT
     hook.Add "Think", playerIdentifierEvent, ->
         hook.Remove "Think", playerIdentifierEvent
         net.Start playerIdentifierEvent
-    net.SendToServer!
+        net.SendToServer!
 
     net.Receive playerIdentifierEvent, ->
         LocalPlayer!.mixpanelIdentifier = net.ReadString!

--- a/moon/gm_mixpanel/base.moon
+++ b/moon/gm_mixpanel/base.moon
@@ -34,6 +34,10 @@ class MixpanelBase
         @MAX_QUEUE_SIZE = 50
         @eventQueue = {}
 
+    _getToken: => getToken!
+
+    _getTimestamp: => getTimestamp!
+
     _clearQueue: =>
         queueSize = #@eventQueue
         for i = 1, queueSize
@@ -73,8 +77,8 @@ class MixpanelBase
     _trackEvent: (eventName, eventProperties, reliable=false) =>
         @_startQueueGroomer! unless timerExists @queueTimer
 
-        eventProperties.token = getToken!
-        eventProperties.time = getTimestamp!
+        eventProperties.token = @_getToken!
+        eventProperties.time = @_getTimestamp!
 
         data =
             event: eventName

--- a/moon/gm_mixpanel/cl_menu.moon
+++ b/moon/gm_mixpanel/cl_menu.moon
@@ -8,6 +8,6 @@ populatePanel = (panel) ->
 hook.Add "AddToolMenuCategories", "Mixpanel_Menu_Category",  ->
     AddToolCategory "Options", "Telemetry", "Telemetry"
 
-hook.Add "PopulateToolMenu", "CFC_Punt_MenuOption", ->
+hook.Add "PopulateToolMenu", "Mixpanel_MenuOption", ->
     AddToolMenuOption "Options", "Telemetry", "mixpanel_opt_out", "Telemetry", "", "", (panel) ->
         populatePanel panel

--- a/moon/gm_mixpanel/cl_menu.moon
+++ b/moon/gm_mixpanel/cl_menu.moon
@@ -1,0 +1,13 @@
+import AddToolCategory, AddToolMenuOption from spawnmenu
+optOut = GetConVar "mixpanel_opt_out"
+
+populatePanel = (panel) ->
+    label = "Opt out of player telemetry"
+    panel\CheckBox label, "mixpanel_opt_out"
+
+hook.Add "AddToolMenuCategories", "Mixpanel_Menu_Category",  ->
+    AddToolCategory "Options", "Telemetry", "Telemetry"
+
+hook.Add "PopulateToolMenu", "CFC_Punt_MenuOption", ->
+    AddToolMenuOption "Options", "Telemetry", "mixpanel_opt_out", "Telemetry", "", "", (panel) ->
+        populatePanel panel

--- a/moon/gm_mixpanel/cl_mixpanel.moon
+++ b/moon/gm_mixpanel/cl_mixpanel.moon
@@ -1,6 +1,9 @@
 import Merge from table
 MixpanelBase = include "gm_mixpanel/base.lua"
 
+optOut = CreateClientConVar "mixpanel_opt_out", 0, true, true, "", 0, 1
+include "gm_mixpanel/cl_menu.lua"
+
 class MixpanelInterface extends MixpanelBase
     getIdentifiers = -> {
         distinct_id: LocalPlayer!\SteamID64!
@@ -8,8 +11,9 @@ class MixpanelInterface extends MixpanelBase
     }
 
     TrackEvent: (name, properties={}, reliable=false) =>
-        Merge properties, getIdentifiers!
+        return if optOut\GetBool!
 
+        Merge properties, getIdentifiers!
         @_trackEvent name, properties, reliable
- 
+
 export Mixpanel = MixpanelInterface!

--- a/moon/gm_mixpanel/sv_mixpanel.moon
+++ b/moon/gm_mixpanel/sv_mixpanel.moon
@@ -1,6 +1,7 @@
 import CRC from util
 import Merge from table
 MixpanelBase = include "gm_mixpanel/base.lua"
+include "gm_mixpanel/sv_profile.lua"
 
 class MixpanelInterface extends MixpanelBase
     _getPlyIdentifiers: (ply) => {
@@ -13,6 +14,8 @@ class MixpanelInterface extends MixpanelBase
         @_trackEvent name, properties, reliable
 
     TrackPlyEvent: (name, ply, properties={}, reliable=false) =>
+        return if ply\GetInfoNum("mixpanel_opt_out", 0) == 1
+
         Merge properties, @_getPlyIdentifiers ply
         @_trackEvent name, properties, reliable
 

--- a/moon/gm_mixpanel/sv_profile.moon
+++ b/moon/gm_mixpanel/sv_profile.moon
@@ -1,4 +1,5 @@
 import CRC from util
+timerExists = timer.Exists
 MixpanelBase = include "gm_mixpanel/base.lua"
 
 class MixpanelProfileInterface extends MixpanelBase

--- a/moon/gm_mixpanel/sv_profile.moon
+++ b/moon/gm_mixpanel/sv_profile.moon
@@ -1,0 +1,34 @@
+import CRC from util
+MixpanelBase = include "gm_mixpanel/base.lua"
+
+class MixpanelProfileInterface extends MixpanelBase
+    new: =>
+        super!
+        @trackUrl = "http://api.mixpanel.com/engage"
+        @queueTimer = "Mixpanel_ProfileQueueGroomer"
+
+    _getPlyIdentifiers: (ply) => {
+        distinct_id: ply\SteamID64!
+        ip: CRC ply\IPAddress!
+    }
+
+    _trackEvent: => error "Not Implemented!"
+
+    _trackProfile: (plyData) =>
+        @_startQueueGroomer! unless timerExists @queueTimer
+
+        plyData.token = getToken!
+        plyData.time = getTimestamp!
+
+        @_queueEvent data
+
+    MakeProfile: (ply) =>
+        return if ply\GetInfoNum("mixpanel_opt_out", 0) == 1
+
+        data = @_getPlyIdentifiers ply
+        @_trackProfile @_getPlyIdentifiers ply
+
+profileInterface = MixpanelProfileInterface!
+
+hook.Add "PlayerInitialSpawn", "Mixpanel_TrackProfile", (ply) ->
+    profileInterface\MakeProfile ply

--- a/moon/gm_mixpanel/sv_profile.moon
+++ b/moon/gm_mixpanel/sv_profile.moon
@@ -17,8 +17,8 @@ class MixpanelProfileInterface extends MixpanelBase
     _trackProfile: (plyData) =>
         @_startQueueGroomer! unless timerExists @queueTimer
 
-        plyData.token = getToken!
-        plyData.time = getTimestamp!
+        plyData.token = @_getToken!
+        plyData.time = @_getTimestamp!
 
         @_queueEvent data
 


### PR DESCRIPTION
Turns out Mixpanel doesn't create profiles for users, even if you're passing them a distinct ID.
We'll have to manually create a new profile for each player if we want to be able to treat `disctint_ids` as references in our data.